### PR TITLE
Add dash in Ids

### DIFF
--- a/src/helpers/idTemplates.ts
+++ b/src/helpers/idTemplates.ts
@@ -73,9 +73,9 @@ export function approvedOperatorId(assetAddress: string, ownerAddress: string): 
 }
 
 export function depositCapId(chargedSettingsAddress: string, assetTokenAddress: string): string {
-  return chargedSettingsAddress + assetTokenAddress;
+  return chargedSettingsAddress + '-' + assetTokenAddress;
 }
 
 export function maxNftsId(contractAddress: string, assetTokenAddress: string): string {
-  return contractAddress + assetTokenAddress;
+  return contractAddress + '-' + assetTokenAddress;
 }


### PR DESCRIPTION
Minor update - add missing `-` in the idTemplate functions for `maxNfts` and `depositCapId`