### PR TITLE
Add userTokenMetrics

### DIFF
--- a/generated/schema.ts
+++ b/generated/schema.ts
@@ -4521,13 +4521,13 @@ export class UserTokenMetric extends Entity {
     this.set("id", Value.fromString(value));
   }
 
-  get totalValueLocked(): BigInt {
-    let value = this.get("totalValueLocked");
+  get lifetimeValueLocked(): BigInt {
+    let value = this.get("lifetimeValueLocked");
     return value.toBigInt();
   }
 
-  set totalValueLocked(value: BigInt) {
-    this.set("totalValueLocked", Value.fromBigInt(value));
+  set lifetimeValueLocked(value: BigInt) {
+    this.set("lifetimeValueLocked", Value.fromBigInt(value));
   }
 
   get totalMassReleased(): BigInt {

--- a/schema.graphql
+++ b/schema.graphql
@@ -571,7 +571,7 @@ type ProfileMetric @entity {
 type UserTokenMetric @entity {
   id: ID!
 
-  totalValueLocked: BigInt!
+  lifetimeValueLocked: BigInt!
   totalMassReleased: BigInt!
   totalInterestDischarged: BigInt!
 }

--- a/src/helpers/idTemplates.ts
+++ b/src/helpers/idTemplates.ts
@@ -81,5 +81,9 @@ export function assetTokenId(assetTokenAddress: string): string {
 }
 
 export function profileMetricId(userAddress: string): string {
-  return userAddress
+  return userAddress;
+}
+
+export function userTokenMetricId(userAddress: string, assetTokenAddress: string): string {
+  return userAddress + '-' + assetTokenAddress;
 }

--- a/src/helpers/loadOrCreateUserTokenMetric.ts
+++ b/src/helpers/loadOrCreateUserTokenMetric.ts
@@ -1,0 +1,28 @@
+import { Address } from '@graphprotocol/graph-ts';
+
+import {
+  UserTokenMetric
+} from '../../generated/schema';
+
+import { userTokenMetricId } from './idTemplates';
+
+import { ZERO } from './common';
+
+export function loadOrCreateUserTokenMetric(
+  userAddress: Address,
+  assetTokenAddress: Address,
+): UserTokenMetric {
+  const id = userTokenMetricId(userAddress.toHex(), assetTokenAddress.toHex());
+  let _userTokenMetric = UserTokenMetric.load(id);
+
+
+  if (!_userTokenMetric) {
+    _userTokenMetric = new UserTokenMetric(id);
+    _userTokenMetric.totalInterestDischarged = ZERO;
+    _userTokenMetric.totalMassReleased = ZERO;
+    _userTokenMetric.lifetimeValueLocked = ZERO;
+    _userTokenMetric.save();
+  }
+
+  return  _userTokenMetric as UserTokenMetric;
+}


### PR DESCRIPTION
Add 3 new metrics for profile/token address level statistics
* Lifetime value locked (how much has a user locked in a given token over the lifetime of the user's address)
* Total mass discharged (how many tokens has the user discharged over the lifetime of the user's address)
* Total interest discharged (how much interest has been discharged to a user's address over the lifetime of the address - includes both creator interest and owner interest discharge)