### PR TITLE
Check for attributes property on NFT metadata

### DIFF
--- a/src/mappingForProton.ts
+++ b/src/mappingForProton.ts
@@ -230,7 +230,16 @@ export function processProtonMetadata(value: JSONValue, userData: Value): void {
 
   _nft.save();
 
-  const attributes = protonMetadata.get('attributes').toArray();
+
+  const attributesObject = protonMetadata.get('attributes');
+
+  if (!attributesObject) {
+    return;
+  }
+
+  const attributes = attributesObject.toArray();
+
+
   for (let i = 0; i < attributes.length; i++) {
     const attrMap = attributes[i].toObject();
 
@@ -246,5 +255,5 @@ export function processProtonMetadata(value: JSONValue, userData: Value): void {
     nftAttr.name = attrName;
     nftAttr.value = attrValue;
     nftAttr.save();
-  }
+  }  
 }


### PR DESCRIPTION
Check for `attributes` property on JSON metadata retrieved from IPFS before array-ifying it catch Protons minted with a missing attribute property like [this one](https://kovan.etherscan.io/token/0xd4f7389297d9cea850777ea6ccbd7db5817a12b2?a=104).  The subgraph will halt otherwise on [this line](https://github.com/Charged-Particles/charged-particles-subgraph/blob/b2c1e9122a37be0de6c4bc9432104278886798a8/src/mappingForProton.ts#L233)