### PR TITLE
Remove filter for bad ipfs hashes

### DIFF
--- a/src/helpers/common.ts
+++ b/src/helpers/common.ts
@@ -35,12 +35,6 @@ export function parseJsonFromIpfs(jsonUri: string): Wrapped<JSONValue> | null {
     return null;
   }
 
-  if (ipfsHash == 'QmcfMBWdXMubqGGS6nYKNJXAeB9PTJpCH8NTuzN5uGLkvp' || ipfsHash == 'QmagSLXM2wp8sXqaAm9fVJvcCXq4JJormeWo9JtkBnFFjB'
-  || ipfsHash == 'QmaFm4cNns9oKhX6uX78mBvf95nE2pyCKm5Fqn5T2cf93U') {
-    log.info('{} RETURNS 504 ON IPFS', [ipfsHash])
-    return null;
-  }
-
   let data = ipfs.cat(ipfsHash);
   if (!data || (data as Bytes).length < 1) {
     log.info('JSON DATA FROM IPFS IS EMPTY {}', [ipfsHash]);


### PR DESCRIPTION
Removes special handling for specific IPFS hashes that were causing timeouts as the issue is now resolved on the graph node codebase [here](https://github.com/graphprotocol/graph-node/issues/2351).  I've redeployed our kovan subgraph [here](https://thegraph.com/explorer/subgraph/charged-particles/kovan-acolytec3) and it is now syncing correctly with those edits removed.