### PR TITLE
update IONX address for kovan to proper version

### DIFF
--- a/networks/kovan.json
+++ b/networks/kovan.json
@@ -65,7 +65,7 @@
     "startBlock": "30754837"
   },
   "ionx": {
-    "address": "0x3D88F7eEFB4a836DcE1944838946E41BC5c59804",
+    "address": "0xD2eAb3D155DD5a0c5745ce4661650E3Cb266c329",
     "startBlock": "30754837"
   },
 


### PR DESCRIPTION
old ionx address got added here incorrectly ... `0x...c329` is the correct one